### PR TITLE
Fix asterisk key not working by adding proper KEY_KPASTERISK mapping

### DIFF
--- a/numberpad.py
+++ b/numberpad.py
@@ -208,7 +208,9 @@ def set_defaults_keysym_name_associated_to_evdev_key_reflecting_current_layout()
         mod_name_to_specific_keysym_name('Control'): '',
         'u': '',
         # unicode shortcut - end sequence
-        'space': ''
+        'space': '',
+        # numpad keys
+        'asterisk': ''
     }
 
 
@@ -306,6 +308,10 @@ def load_evdev_keys_for_x11():
     reset_udev_device()
 
   keymap_loaded = True
+  
+  # Manual mapping for asterisk key to fix keysym resolution issue
+  set_evdev_key_for_char('asterisk', EV_KEY.KEY_KPASTERISK)
+  enable_key(EV_KEY.KEY_KPASTERISK)
 
   log.debug("X11 loaded keymap succesfully")
   log.debug(get_keysym_name_associated_to_evdev_key_reflecting_current_layout())
@@ -421,6 +427,10 @@ def wl_load_keymap_state():
         reset_udev_device()
 
     keymap_loaded = True
+    
+    # Manual mapping for asterisk key to fix keysym resolution issue
+    set_evdev_key_for_char('asterisk', EV_KEY.KEY_KPASTERISK)
+    enable_key(EV_KEY.KEY_KPASTERISK)
 
     log.debug("Wayland loaded keymap succesfully")
     log.debug(get_keysym_name_associated_to_evdev_key_reflecting_current_layout())


### PR DESCRIPTION
Fixes asterisk key issues where pressing * resulted in invalid key codes or caused NumberPad to turn off immediately.

Hardcoded solution for ASUS Zenbook UM3402YA series.

The root cause was that "asterisk" string in layout files was being resolved to invalid key codes like KEY_2F8:760 or KEY_54:84 instead of the proper KEY_KPASTERISK:55.

This fix:
- Adds 'asterisk' to default keysym mapping dictionary
- Manually maps 'asterisk' to KEY_KPASTERISK in both X11 and Wayland
- Enables KEY_KPASTERISK in the virtual input device

Tested on Pop\!_OS GNOME (Wayland) with up5401ea layout.

Before: [KEY_LEFTSHIFT:42, KEY_2F8:760, KEY_8:9] (broken)
After: KEY_KPASTERISK:55 (working correctly)
